### PR TITLE
Multicomparison agreement pie/bar plot

### DIFF
--- a/spikewidgets/tests/test_widgets.py
+++ b/spikewidgets/tests/test_widgets.py
@@ -65,6 +65,8 @@ class TestWidgets(unittest.TestCase):
     def test_multicomp_graph(self):
         msc = sc.compare_multiple_sorters([self._SX, self._SX, self._SX])
         sw.plot_multicomp_graph(msc, edge_cmap='viridis', node_cmap='rainbow', draw_labels=False)
+        sw.plot_multicomp_agreement(msc)
+        sw.plot_multicomp_agreement_by_sorter(msc)
 
 
 if __name__ == '__main__':

--- a/spikewidgets/widgets/basewidget.py
+++ b/spikewidgets/widgets/basewidget.py
@@ -25,6 +25,7 @@ class BaseWidget:
     def get_name(self):
         return self.name
 
+
 class BaseMultiWidget:
     def __init__(self, figure=None, ax=None):
         if figure is None and ax is None:

--- a/spikewidgets/widgets/featurewidgets/pcawidget.py
+++ b/spikewidgets/widgets/featurewidgets/pcawidget.py
@@ -68,7 +68,8 @@ class PCAWidget(BaseMultiWidget):
                                                                      by_electrode=True,
                                                                      max_spikes_per_unit=self._max_spikes_per_unit,
                                                                      save_as_features=self._save_as_features,
-                                                                     save_waveforms_as_features=self._save_waveforms_as_features)
+                                                                     save_waveforms_as_features=
+                                                                     self._save_waveforms_as_features)
 
     def plot(self):
         self._do_plot()

--- a/spikewidgets/widgets/isidistwidget/isidistwidget.py
+++ b/spikewidgets/widgets/isidistwidget/isidistwidget.py
@@ -49,7 +49,7 @@ def plot_isi_distribution(sorting, sampling_frequency=None, unit_ids=None, bins=
 
 
 class ISIDistributionWidget(BaseMultiWidget):
-    def __init__(self, *, sorting, sampling_frequency, unit_ids=None, bins=10, window=1, figure=None, ax=None):
+    def __init__(self, *, sorting, sampling_frequency, unit_ids=None, bins=10, window=1., figure=None, ax=None):
         BaseMultiWidget.__init__(self, figure, ax)
         self._sorting = sorting
         self._unit_ids = unit_ids

--- a/spikewidgets/widgets/multicompgraphwidget/__init__.py
+++ b/spikewidgets/widgets/multicompgraphwidget/__init__.py
@@ -1,1 +1,1 @@
-from .multicompgraphwidget import plot_multicomp_graph
+from .multicompgraphwidget import plot_multicomp_graph, plot_multicomp_agreement, plot_multicomp_agreement_by_sorter

--- a/spikewidgets/widgets/multicompgraphwidget/multicompgraphwidget.py
+++ b/spikewidgets/widgets/multicompgraphwidget/multicompgraphwidget.py
@@ -143,9 +143,9 @@ class MultiCompGraphWidget(BaseWidget):
             n1, n2, d = e
             edge_col.append(d['weight'])
         nodes_col = np.array([])
-        for i, sort in enumerate(self._msc.get_sorting_list()):
+        for i, sort in enumerate(self._msc.sorting_list):
             nodes_col = np.concatenate((nodes_col, np.array([i] * len(sort.get_unit_ids()))))
-        nodes_col = nodes_col / len(self._msc.get_sorting_list())
+        nodes_col = nodes_col / len(self._msc.sorting_list)
 
         _ = plt.set_cmap(self._node_cmap)
         _ = nx.draw_networkx_nodes(g, pos=nx.circular_layout(sorted(g)), nodelist=sorted(g.nodes),
@@ -225,7 +225,7 @@ class MultiCompAgreementBySorterWidget(BaseMultiWidget):
             v, c = np.unique([len(np.unique(sn)) for sn in sg_names if name in sn], return_counts=True)
             if self._type == 'pie':
                 p = ax.pie(c, colors=colors[v - 1], textprops={'color': 'k', 'fontsize': self._fs},
-                       autopct=lambda pct: _getabs(pct, c),  pctdistance=1.15)
+                           autopct=lambda pct: _getabs(pct, c),  pctdistance=1.15)
                 if i == len(name_list) - 1:
                     plt.legend(p[0], v, frameon=False, title='k=',
                                bbox_to_anchor=(1.15, 1.25), loc=2, borderaxespad=0., labelspacing=0.2)

--- a/spikewidgets/widgets/multicompgraphwidget/multicompgraphwidget.py
+++ b/spikewidgets/widgets/multicompgraphwidget/multicompgraphwidget.py
@@ -239,6 +239,11 @@ class MultiCompAgreementBySorterWidget(BaseMultiWidget):
             else:
                 raise AttributeError("Wrong plot_type. It can be 'pie' or 'bar'")
             ax.set_title(name)
+        if self._type == 'bar':
+            ylims = [np.max(ax_single.get_ylim()) for ax_single in self.axes]
+            max_yval = np.max(ylims)
+            for ax_single in self.axes:
+                ax_single.set_ylim([0, max_yval])
 
         self.figure.set_size_inches((len(name_list) * 2, 2.4))
 


### PR DESCRIPTION
Implemented pie and bar plots for agreement sorting.

Requires this PR https://github.com/SpikeInterface/spikecomparison/pull/31

@mhhennig 

## Global agreement
`sw.plot_multicomp_agreement(mcmp, cmap='viridis', plot_type='bar')`
- Pie     
![image](https://user-images.githubusercontent.com/17097257/79041455-5cf2b980-7bf0-11ea-9afc-c353b169c58a.png)

- Bar  
![image](https://user-images.githubusercontent.com/17097257/79041466-6c720280-7bf0-11ea-87e0-e6289d5a0813.png)

## Agreement by sorter
`sw.plot_multicomp_agreement_by_sorter(mcmp, plot_type='pie')`

- Pie
![image](https://user-images.githubusercontent.com/17097257/79041499-b0650780-7bf0-11ea-8411-2608540c6038.png)

- Bar
![image](https://user-images.githubusercontent.com/17097257/79041506-bc50c980-7bf0-11ea-88aa-edd0b42b282a.png)
